### PR TITLE
Support monitor.isDragging bool

### DIFF
--- a/src/KeyboardBackend.tsx
+++ b/src/KeyboardBackend.tsx
@@ -188,7 +188,10 @@ export class KeyboardBackend implements Backend {
       clientOffset: this.getSourceClientOffset(sourceId),
       getSourceClientOffset: this.getSourceClientOffset,
       publishSource: false,
+      item: this.monitor.getItem(),
+      itemType: this.monitor.getItemType(),
     });
+    this.actions.publishDragSource();
     this._previewer.render(this.monitor);
     this.setDndMode(true);
     this._announcer.announceDrag(sourceNode, sourceId);


### PR DESCRIPTION
Fixing a bug where `monitor.isDragging()` is always false for the KeyboardBackend because it doesn't provide the proper options and call to publish the drag source