### PR TITLE
relax peerDependencies to allow new versions of react/react-dnd

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepublishOnly": "npm run -s build"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dnd": "14.0.0"
+    "react": ">=16.8.0",
+    "react-dnd": ">=14.0.0"
   },
   "devDependencies": {
     "@types/react": "17.0.26",


### PR DESCRIPTION
Fixes https://github.com/discord/react-dnd-accessible-backend/issues/8.

We still want to have the peerDependencies on the off-chance that someone consuming the library hasn't upgraded past React 16.8.0 or react-dnd 14.0.0, as lower versions wouldn't be able to support the hooks APIs that this library is based on.

But this should allow any newer versions.