### PR TITLE
Don't let users `Tab` to other elements when dragging

### DIFF
--- a/packages/react-dnd-accessible-backend/KeyboardBackend.tsx
+++ b/packages/react-dnd-accessible-backend/KeyboardBackend.tsx
@@ -20,6 +20,7 @@ import type { AnnouncementMessages } from "./util/AnnouncementMessages";
 const Trigger = {
   DROP: [" ", "Enter"],
   CANCEL_DRAG: ["Escape"],
+  TAB: ["Tab"],
 };
 
 function isTrigger(event: KeyboardEvent, trigger: typeof Trigger[keyof typeof Trigger]) {
@@ -112,6 +113,8 @@ export class KeyboardBackend implements Backend {
       const sourceNode = this.sourceNodes.get(sourceId);
       this._announcer.announceCancel(sourceNode ?? null, sourceId);
     }
+    // Prevent tabbing to other elements when dragging locking the focus on drag source
+    if (this.monitor.isDragging() && isTrigger(event, Trigger.TAB)) event.preventDefault();
   };
 
   private setDndMode(enabled: boolean) {


### PR DESCRIPTION
When drag and drop mode is turned on (i.e an item is being dragged ~ `isDragging()` is true) ensure that users cannot tab to other elements on the screen.

Note: I was thinking of adding tests for this but saw that we didn't have any testing library for [react-dnd-accessible-backend](https://github.com/discord/react-dnd-accessible-backend). Is there any preference? I was thinking of installing [Jest](https://jestjs.io/) for unit tests but wanted to make sure that its okay before making any changes on that. I can start a follow-up PR to add some tests around some of these things if we can finalize a library to use. 